### PR TITLE
NOJIRA: use report.results.length instead of this.filesSrc.length for # of files linted

### DIFF
--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -65,7 +65,7 @@ module.exports = function (grunt) {
 			grunt.warn('ESLint found too many warnings (maximum:' + opts.maxWarnings + ')');
 		}
 		if (report.errorCount === 0) {
-      grunt.log.ok(this.filesSrc.length + ' ' + grunt.util.pluralize(this.filesSrc.length, 'file/files') + ' lint free.');
+      grunt.log.ok(report.results.length + ' ' + grunt.util.pluralize(report.results.length, 'file/files') + ' lint free.');
 		}
 
 		return report.errorCount === 0;


### PR DESCRIPTION
@jobara & I noticed that the # of files linted for some projects was much higher than it should be. By default `grunt-eslint` chooses what to lint based on a two-step process:
1) all files globbed the Grunt lint task definition are passed to eslint
2) eslint filters those files based on the `.eslintignore` file, if present, then lints whatever remains

Using `this.filesSrc.length` results in the number of lint-free files being reported as the number from step 1; `report.results.length` instead uses the number of files actually linted by eslint (some details in this closed issue at https://github.com/eslint/eslint/issues/855)

The difference is easy to see by locally patching or using my fork in a project such as https://github.com/waharnum/myl3/tree/FLOE-471, which reports 364 files lint-free (`this.fileSrc.length`) vs. 6 lint-free (`report.results.length`).
